### PR TITLE
tls,oauth2: allow to opt out service support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     name: Notify Slack
     needs:
       - build
-    if: always()
+    if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Prepare Slack message

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_REPO := $(shell git ls-remote --get-url)
 EXECUTABLE := "quorum-security-plugin-enterprise"
 PACKAGE ?= quorum-security-plugin-enterprise
 OUTPUT_DIR := "$(shell pwd)/build"
-VERSION := "1.0.0"
+VERSION := "0.0.0"
 LD_FLAGS="-X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH} -X main.GitRepo=${GIT_REPO} \
 -X main.Executable=${EXECUTABLE} -X main.Version=${VERSION} -X main.OutputDir=${OUTPUT_DIR}"
 XC_ARCH := amd64

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+# Quorum Enterprise Security Plugin
+
 This is to provide a backend support for `geth` JSON RPC servers by implementing services from [security plugin interface](https://github.com/jpmorganchase/quorum-plugin-definitions/blob/master/security.proto):
 
 - `TLSConfigurationSource` to provide TLS configuration for HTTP and WS RPC servers
-- `AuthenticationManager` to enable RPC servers being OAuth2-compliant resource servers 
+- `AuthenticationManager` to enable RPC servers being OAuth2-compliant resource servers
 that support both JSON Web Token ([JWT](https://tools.ietf.org/html/rfc7519)) and opaque access token format
 
 ## Prerequisites
@@ -17,7 +19,7 @@ $ PLUGIN_DIST_PATH=<path to store plugin distribution zip file> make dist
 
 ## Configuration
 
-Refer to the official documentation [here](http://docs.goquorum.com/en/latest/PluggableArchitecture/Plugins/security/implementation/) for more details
+Refer to the official documentation [here](http://docs.goquorum.com/en/latest/PluggableArchitecture/Plugins/security/For-Users/) for more details
 
 ## Token Validation
 

--- a/examples/node-0/plugins.json
+++ b/examples/node-0/plugins.json
@@ -2,7 +2,7 @@
   "providers": {
     "security": {
       "name":"quorum-security-plugin-enterprise",
-      "version":"0.1.0",
+      "version":"0.1.1",
       "config": "env://SECURITY_CONFIG?type=file"
     }
   }

--- a/examples/node-1/plugins.json
+++ b/examples/node-1/plugins.json
@@ -2,7 +2,7 @@
   "providers": {
     "security": {
       "name":"quorum-security-plugin-enterprise",
-      "version":"0.1.0",
+      "version":"0.1.1",
       "config": "env://SECURITY_CONFIG?type=file"
     }
   }

--- a/examples/node-2/plugins.json
+++ b/examples/node-2/plugins.json
@@ -2,7 +2,7 @@
   "providers": {
     "security": {
       "name":"quorum-security-plugin-enterprise",
-      "version":"0.1.0",
+      "version":"0.1.1",
       "config": "env://SECURITY_CONFIG?type=file"
     }
   }

--- a/examples/quorum.yml
+++ b/examples/quorum.yml
@@ -83,7 +83,7 @@ x-tx-manager-def:
 services:
   node0:
     << : *quorum-def
-    image: quorumengineering/quorum:latest
+    image: ${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:latest}
     container_name: quorum-node0
     hostname: node0
     ports:
@@ -108,7 +108,7 @@ services:
       - NODEKEY_HEX=c49d54d1cef9ab90a370ca9695824670288b97bdd246673e420b2169c2be7a8a
   tm0:
     << : *tx-manager-def
-    image: quorumengineering/tessera:0.10.3
+    image: ${TESSERA_DOCKER_IMAGE:-quorumengineering/tessera:0.10.3}
     container_name: quorum-tm0
     hostname: txmanager0
     ports:
@@ -121,7 +121,7 @@ services:
         ipv4_address: 172.16.58.101
   node1:
     << : *quorum-def
-    image: quorumengineering/quorum:latest
+    image: ${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:latest}
     container_name: quorum-node1
     hostname: node1
     ports:
@@ -146,7 +146,7 @@ services:
       - NODEKEY_HEX=6a822990d8295ab9e77ec25825513fbc8e728157ffa20b1de2b87d5548070f43
   tm1:
     << : *tx-manager-def
-    image: quorumengineering/tessera:0.10.3
+    image: ${TESSERA_DOCKER_IMAGE:-quorumengineering/tessera:0.10.3}
     container_name: quorum-tm1
     hostname: txmanager1
     ports:
@@ -159,7 +159,7 @@ services:
         ipv4_address: 172.16.58.102
   node2:
     << : *quorum-def
-    image: quorumengineering/quorum:latest
+    image: ${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:latest}
     container_name: quorum-node2
     hostname: node2
     ports:
@@ -184,7 +184,7 @@ services:
       - NODEKEY_HEX=c5127e8a3d98058182a2832846a1143fb7c75705bdecae0e2f04c9219bf9da23
   tm2:
     << : *tx-manager-def
-    image: quorumengineering/tessera:0.10.3
+    image: ${TESSERA_DOCKER_IMAGE:-quorumengineering/tessera:0.10.3}
     container_name: quorum-tm2
     hostname: txmanager2
     ports:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,22 +82,23 @@ func NewSecurityConfiguration(rawJSON []byte) (*SecurityConfiguration, error) {
 
 // main configuration to protect JSON RPC server
 type SecurityConfiguration struct {
-	EnableMultiTenancyAuthz bool                          `json:"enableMultiTenancyAuthz"`
-	TLSConfig               *TLSConfiguration             `json:"tls"`
-	TokenValidationConfig   *TokenValidationConfiguration `json:"tokenValidation"`
+	TLSConfig             *TLSConfiguration             `json:"tls"`
+	TokenValidationConfig *TokenValidationConfiguration `json:"tokenValidation"`
 }
 
 func (c *SecurityConfiguration) validate() error {
-	if c.TokenValidationConfig == nil {
-		return fmt.Errorf("missing TokenValidation configuration")
+	if c.TokenValidationConfig == nil && c.TLSConfig == nil {
+		return fmt.Errorf("invalid configuration. 'tls' block and/or 'tokenValidation' block must be configured")
 	}
 	if c.TLSConfig != nil {
 		if err := c.TLSConfig.validate(); err != nil {
 			return err
 		}
 	}
-	if err := c.TokenValidationConfig.validate(); err != nil {
-		return err
+	if c.TokenValidationConfig != nil {
+		if err := c.TokenValidationConfig.validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -106,7 +107,9 @@ func (c *SecurityConfiguration) SetDefaults() {
 	if c.TLSConfig != nil {
 		c.TLSConfig.setDefaults()
 	}
-	c.TokenValidationConfig.setDefaults()
+	if c.TokenValidationConfig != nil {
+		c.TokenValidationConfig.setDefaults()
+	}
 }
 
 func (cs CipherSuite) toUint16() (uint16, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -248,6 +248,47 @@ func TestNewSecurityConfiguration_whenValid(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestNewSecurityConfiguration_whenOnlyTLS(t *testing.T) {
+	assert := testifyassert.New(t)
+
+	config, err := NewSecurityConfiguration([]byte(onlyTLSConfiguration))
+
+	assert.NoError(err)
+	assert.Nil(config.TokenValidationConfig)
+	assert.NoError(config.validate())
+}
+
+func TestNewSecurityConfiguration_whenOnlyTokenValidation(t *testing.T) {
+	assert := testifyassert.New(t)
+
+	config, err := NewSecurityConfiguration([]byte(onlyTokenValidationConfiguration))
+
+	assert.NoError(err)
+	assert.Nil(config.TLSConfig)
+	assert.NoError(config.validate())
+}
+
+const onlyTLSConfiguration = `
+{
+  "tls": {
+    "auto": true
+  }
+}
+`
+
+const onlyTokenValidationConfiguration = `
+{
+  "tokenValidation": {
+    "jws": {
+      "endpoint": "https://localhost:5000/keys",
+      "tlsConnection": {
+        "insecureSkipVerify": true
+      }
+    }
+  }
+}
+`
+
 const minimumValidConfiguration = `
 {
   "tls": {

--- a/internal/impl_test.go
+++ b/internal/impl_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jpmorganchase/quorum-security-plugin-sdk-go/proto_common"
-
 	"github.com/jpmorganchase/quorum-security-plugin-sdk-go/proto"
+	"github.com/jpmorganchase/quorum-security-plugin-sdk-go/proto_common"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
@@ -40,7 +39,6 @@ func TestSecurityPluginImpl_Init(t *testing.T) {
 		HostIdentity: "node1",
 		RawConfiguration: []byte(`
 {
-  "enableMultiTenancyAuthz": true,
   "tls": {
     "auto": true
   },
@@ -61,7 +59,6 @@ func TestSecurityPluginImpl_Init(t *testing.T) {
 	assert.NotNil(t, testObject.tlsConfigSource, "tlsSource must be ready")
 	assert.NotNil(t, testObject.authManager, "authManager must be ready")
 	assert.Equal(t, "node1", testObject.config.TokenValidationConfig.Aud)
-
 }
 
 func TestSecurityPluginImpl_Get_whenNoTLSSource(t *testing.T) {

--- a/internal/oauth2/manager.go
+++ b/internal/oauth2/manager.go
@@ -27,6 +27,9 @@ type Manager struct {
 }
 
 func NewManager(conf *config.TokenValidationConfiguration) (*Manager, error) {
+	if conf == nil {
+		return nil, nil
+	}
 	m := &Manager{
 		config: conf,
 	}


### PR DESCRIPTION
The presence of `tls`  or `tokenValidation` configuration block will determine if this plugin supports the corresponding service